### PR TITLE
Add ExistInFlags extension method to FlagsEnumerationExtensions class

### DIFF
--- a/Farsica.Framework/Data/Enumeration/FlagsEnumerationExtensions.cs
+++ b/Farsica.Framework/Data/Enumeration/FlagsEnumerationExtensions.cs
@@ -79,6 +79,18 @@
             return (left & right) == right;
         }
 
+        public static bool ExistInFlags<TEnum>(this TEnum left, TEnum right)
+            where TEnum : FlagsEnumeration<TEnum>, new()
+        {
+            return (left & right) != new TEnum();
+        }
+
+        public static bool ExistInFlags<TEnum>(this FlagsEnumeration<TEnum> left, TEnum right)
+            where TEnum : FlagsEnumeration<TEnum>, new()
+        {
+            return (left & right) != new TEnum();
+        }
+
         public static TEnum SetFlags<TEnum>(this TEnum left, params TEnum[] right)
             where TEnum : FlagsEnumeration<TEnum>, new()
         {


### PR DESCRIPTION
The "ExistInFlags" extension method returns true in case at least one flag from the left-hand operand exists in the right-hand operand. Otherwise, returns false.